### PR TITLE
fix: send stored SPS before PPS

### DIFF
--- a/receiverHub.go
+++ b/receiverHub.go
@@ -159,18 +159,18 @@ func (r *ReceiverHub) run() {
 				if status.gotIFrame {
 					*client.send <- data
 				} else {
-					if !status.gotPPS && r.pps != nil {
-						status.gotPPS = true
-						*client.send <- r.pps
-						if nalUnitType == PPS {
-							client.mutex.Unlock()
-							continue
-						}
-					}
 					if !status.gotSPS && r.sps != nil {
 						status.gotSPS = true
 						*client.send <- r.sps
 						if nalUnitType == SPS {
+							client.mutex.Unlock()
+							continue
+						}
+					}
+					if !status.gotPPS && r.pps != nil {
+						status.gotPPS = true
+						*client.send <- r.pps
+						if nalUnitType == PPS {
 							client.mutex.Unlock()
 							continue
 						}


### PR DESCRIPTION
Invalid order breaks "webcodecs" decoder in Chrome. 
https://github.com/NetrisTV/ws-scrcpy/pull/141